### PR TITLE
Now compiles

### DIFF
--- a/src/lua/lua.rs
+++ b/src/lua/lua.rs
@@ -1,5 +1,4 @@
 pub use self::state::*;
-pub use ffi::LuaCallback;
 use std::hashmap::HashMap;
 mod state;
 


### PR DESCRIPTION
The module `ffi` was not exposed to `lua`, so therefore the library would not compile.  Now it does.
